### PR TITLE
Default to full file linting

### DIFF
--- a/scripts/pre-commit.git-lint.sh
+++ b/scripts/pre-commit.git-lint.sh
@@ -19,7 +19,7 @@ if [ -z "$DIFF_FILES" ]
 then
   exit 0;
 else
-  git diff-index -z --cached HEAD --name-only --diff-filter=ACMRTUXB | xargs -0 git lint;
+  git diff-index -z --cached HEAD --name-only --diff-filter=ACMRTUXB | xargs -0 git lint -f;
 fi
 
 if [ "$?" != "0" ]; then


### PR DESCRIPTION
This PR checks the lint errors that arise on all lines of a file you've changed as opposed to just the lines you have changed, slows down speed a tiny bit